### PR TITLE
Fix test which is not passing with new version of Dokuwiki

### DIFF
--- a/_test/instructions.test.php
+++ b/_test/instructions.test.php
@@ -1,16 +1,18 @@
 <?php
 
-require_once dirname(__FILE__) . '/pageredirect_test.php';
-
 /**
  * @group plugin_pageredirect
  */
-class plugin_pageredirect_test1 extends plugin_pageredirect_abstract_test {
+class plugin_pageredirect_test1 extends DokuWikiTest {
+
+	public function setUp() {
+		$this->pluginsEnabled[] = 'pageredirect';
+		parent::setUp();
+	}
+
 	public function test_instructions() {
 		$instructions = p_get_instructions("~~REDIRECT>namespace:page~~");
 
-		// this is '/tmp' somewhy when ran from IDEA
-		$doku_root = '/.';
 		$expected = array(
 			0 =>
 			array(
@@ -28,7 +30,7 @@ class plugin_pageredirect_test1 extends plugin_pageredirect_abstract_test {
 					1 =>
 					array(
 						0 => 'namespace:page',
-						1 => '<div class="noteredirect">This page has been moved, the new location is <a href="'.$doku_root.'/doku.php?id=namespace:page" class="wikilink2" title="namespace:page" rel="nofollow">page</a>.</div>',
+						1 => '<div class="noteredirect">This page has been moved, the new location is <a href="'.DOKU_BASE.'doku.php?id=namespace:page" class="wikilink2" title="namespace:page" rel="nofollow">page</a>.</div>',
 					),
 					2 => 5,
 					3 => '~~REDIRECT>namespace:page~~',

--- a/_test/pageredirect_test.php
+++ b/_test/pageredirect_test.php
@@ -1,8 +1,0 @@
-<?php
-
-class plugin_pageredirect_abstract_test extends DokuWikiTest {
-	public function setUp() {
-		$this->pluginsEnabled[] = 'pageredirect';
-		parent::setUp();
-	}
-}


### PR DESCRIPTION
First failure was: No tests found in class "plugin_pageredirect_abstract_test".
Second failure was: Expected "/tmp/" to be "/./"
